### PR TITLE
OCR temp-orphan cleanup + AppArmor scratch-dir constraint

### DIFF
--- a/docs/database/ocr_processing_guide.md
+++ b/docs/database/ocr_processing_guide.md
@@ -78,6 +78,47 @@ Options:
 | `--redo` | Re-OCR pages that already have text (`--redo-ocr`), to correct wrong-language OCR. Bypasses the has-text skip. |
 | `--report PATH` | Use a different report XLSX — for resuming a partial run from a filtered list. |
 | `--timeout N` | Per-file `ocrmypdf` timeout in seconds (default 600). Raise for multi-hundred-page volumes. |
+| `--tmpdir PATH` | Where ocrmypdf renders pages. See the disk-space and AppArmor notes below — the path is constrained. |
+
+### Temp space and the AppArmor constraint (read before setting `--tmpdir`)
+
+`ocrmypdf` rasterises **every page to PNG at 400 DPI** before OCR, so one
+400–1000 page volume can need several GB of scratch at once. Two traps:
+
+1. **A full temp dir fails everything, silently.** If the temp filesystem
+   fills, Ghostscript fails at *startup* and every subsequent file fails
+   fast with an empty/garbled error and idle CPU. The usual cause is
+   orphaned `ocrmypdf.io.*` dirs left by `kill -9`'d runs — ocrmypdf
+   cleans up on normal completion but not when killed. `ocr_library.py`
+   now clears these at startup when `--tmpdir` is set; otherwise clean
+   manually: `rm -rf /tmp/ocrmypdf.io.*`.
+
+2. **Ghostscript is AppArmor-confined.** `/etc/apparmor.d/gs` restricts
+   `gs` to `/tmp`, `/var/tmp`, and `$HOME` (via `abstractions/user-tmp`).
+   Pointing `--tmpdir` at anything else — notably `/media/**` — makes
+   *every* file fail with:
+
+   ```
+   Last OS error: Permission denied
+   Could not open the scratch file /media/.../gs_XXXXXX
+   SubprocessOutputError: Ghostscript rasterizing failed
+   ```
+
+   Note this is invisible in the log, because `ocr_one` truncates stderr
+   to 200 chars and the Ghostscript banner fills it. To diagnose, run
+   `ocrmypdf` directly on one file and read the full stderr.
+
+**Use `/var/tmp/ocr_scratch`** (permitted, disk-backed rather than the
+RAM-backed `/tmp`). To use a larger disk, add an AppArmor exception
+first:
+
+```bash
+sudo tee /etc/apparmor.d/local/gs >/dev/null <<'EOF'
+owner /media/simon/data/ocr_scratch/** rwk,
+/media/simon/data/ocr_scratch/ r,
+EOF
+sudo apparmor_parser -r /etc/apparmor.d/gs
+```
 
 **Per-report logs:** with `--report`, the log is named
 `logs/ocr_library_log_<report_stem>.txt`, so concurrent or sequential

--- a/scripts/ocr_library.py
+++ b/scripts/ocr_library.py
@@ -95,6 +95,30 @@ def read_flagged_pdfs(report: Path = REPORT) -> list[tuple[str, Path]]:
     return rows
 
 
+# Ghostscript reprints a multi-line version/copyright banner on every
+# retry. That noise used to fill the old 200-char error cap and hide the
+# actual failure (e.g. an AppArmor "Permission denied" on the temp dir),
+# which made whole-run failures effectively undiagnosable from the log.
+_GS_BANNER_RX = re.compile(
+    r"^(\d+\s+)?(GPL Ghostscript [\d.]+ \(|Copyright \(C\)"
+    r"|This software is supplied|see the file COPYING"
+    r"|Current allocation mode|--dict:)"
+)
+
+
+def clean_stderr(raw: bytes, limit: int = 2000) -> str:
+    """Condense ocrmypdf/Ghostscript stderr down to the informative part.
+
+    Strips the repeated Ghostscript banner and keeps the *tail*, since the
+    conclusive error (e.g. "SubprocessOutputError: Ghostscript rasterizing
+    failed") comes last.
+    """
+    text = raw.decode("utf-8", errors="replace")
+    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    lines = [l for l in lines if not _GS_BANNER_RX.match(l)]
+    return " | ".join(lines)[-limit:]
+
+
 def ocr_one(pdf_path: Path, lang: str, available: set[str],
             redo: bool = False, timeout: int = 600) -> tuple[bool, str]:
     """OCR one PDF in place. Returns (success, message).
@@ -148,10 +172,11 @@ def ocr_one(pdf_path: Path, lang: str, available: set[str],
                 capture_output=True, timeout=600,
             )
             if result.returncode != 0 or not tmp_path.exists() or tmp_path.stat().st_size == 0:
-                err = result.stderr.decode("utf-8", errors="replace")[:200]
+                err = clean_stderr(result.stderr)
                 if tmp_path.exists():
                     tmp_path.unlink()
-                return False, f"ocrmypdf failed ({tlang_used}): {err}"
+                return False, (f"ocrmypdf failed ({tlang_used}, rc="
+                               f"{result.returncode}): {err}")
 
         # Atomic replace
         os.replace(tmp_path, pdf_path)
@@ -192,7 +217,13 @@ def main():
                     help="directory for ocrmypdf's page-render temp files. "
                          "Set to a large disk — a big volume can render several "
                          "GB and the default /tmp is often a small tmpfs that "
-                         "fills up and makes every subsequent file fail.")
+                         "fills up and makes every subsequent file fail. "
+                         "MUST be a path Ghostscript's AppArmor profile allows "
+                         "(/tmp, /var/tmp, $HOME — see /etc/apparmor.d/gs). "
+                         "/media/** is DENIED by default: gs then fails with "
+                         "'Permission denied ... Ghostscript rasterizing "
+                         "failed' on every file. To use another disk, add an "
+                         "/etc/apparmor.d/local/gs exception first.")
     args = ap.parse_args()
 
     # Point ocrmypdf's temp at a roomy disk (inherited by the subprocess env).

--- a/scripts/ocr_library.py
+++ b/scripts/ocr_library.py
@@ -20,6 +20,7 @@ import argparse
 import os
 import re
 import subprocess
+import shutil
 import sys
 from pathlib import Path
 from datetime import datetime
@@ -200,6 +201,11 @@ def main():
         os.environ["TMPDIR"] = args.tmpdir
         os.environ["TMP"] = args.tmpdir
         os.environ["TEMP"] = args.tmpdir
+        # Clear stale ocrmypdf temp orphans from prior killed runs. A full
+        # temp dir makes Ghostscript fail at startup, silently failing every
+        # file; runs are sequential so any ocrmypdf.io.* here is a leftover.
+        for stale in Path(args.tmpdir).glob("ocrmypdf.io.*"):
+            shutil.rmtree(stale, ignore_errors=True)
         print(f"Temp dir for OCR: {args.tmpdir}")
 
     report_path = Path(args.report) if args.report else REPORT


### PR DESCRIPTION
Follow-up to #15 with two OCR robustness fixes that landed on the branch after that merge.

- **Clear stale ocrmypdf temp orphans at startup** — a `/tmp` full of `ocrmypdf.io.*` left by kill-9'd runs makes Ghostscript fail at startup, so every file fails fast. `ocr_library.py` now clears these orphans on startup.
- **Surface real ocrmypdf errors + document the AppArmor constraint** — `ocr_one` previously truncated stderr to 200 chars, masking the real cause (the gs banner filled it). Errors are now surfaced. Documents that Ghostscript is AppArmor-confined (`/etc/apparmor.d/gs`) to `/tmp`, `/var/tmp`, and `$HOME`; a local exception is required to use `/media/simon/data/ocr_scratch` as `--tmpdir`.

Touches `scripts/ocr_library.py` and `docs/database/ocr_processing_guide.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)